### PR TITLE
Add support for Github Alerts within markdown

### DIFF
--- a/content/blog/dtls-one-three.md
+++ b/content/blog/dtls-one-three.md
@@ -79,6 +79,7 @@ DTLS 1.3 uses a variable-length unified header that can be as small as **2 bytes
      E = Epoch
 ```
 
+> [!NOTE]
 > With Pion's default MTU of 1200, you could save **50 MB** on a **5 GiB transfer!** That might not sound like a lot, but at scale, it will add up to massive savings.
 
 ### Connects Faster
@@ -89,6 +90,7 @@ With DTLS 1.3, each side can send explicit `ACK` messages. This allows selective
 
 **Second, DTLS 1.3 allows a key share in the `ClientHello`.** This removes an entire round trip. The server no longer waits for the `ClientKeyExchange`!
 
+> [!NOTE]
 > This allows the handshake to be shrunk down to only **1 RTT** (from **2** in DTLS 1.2).
 
 Below are simplified versions of the handshakes. Note how the client only has to wait for one server flight to receive encrypted data (Application Data)

--- a/static/styles.css
+++ b/static/styles.css
@@ -137,7 +137,7 @@ footer {
     width: 50%;
 }
 
-.intro + .intro {
+.intro+.intro {
     margin-top: 1.5rem;
 }
 
@@ -258,13 +258,101 @@ hr {
     }
 
     & blockquote {
-        padding: 0.75rem 1rem;
+        border-left: 3px solid light-dark(#0000004f, #ffffff40);
+        padding-left: 10px;
 
-        border-left: 4px solid var(--link-color);
-        border-radius: 4px;
+        font-size: 0.85em;
 
-        background-color: light-dark(#ffffff, #ffffff0a);
-        font-size: 1.05rem;
+        & * {
+            opacity: 0.9;
+        }
+    }
+
+    & [class^=markdown-alert] {
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+
+        & * {
+            opacity: 1.0;
+        }
+
+        &::before {
+            display: flex;
+            font-size: 0.8em;
+            padding-bottom: 0.35rem;
+        }
+    }
+
+    --alert-color-light: 70% 0.13;
+    --alert-color-dark: 62% 0.13;
+
+    --alert-color-light-text: 45% 0.13;
+    --alert-color-dark-text: 80% 0.13;
+
+    --alert-note: 245;
+    --alert-tip: 145;
+    --alert-important: 323;
+    --alert-warning: 69;
+    --alert-caution: 23;
+
+    & .markdown-alert-note {
+        border-left: 3px solid light-dark(oklch(var(--alert-color-light) var(--alert-note)),
+                oklch(var(--alert-color-dark) var(--alert-note)));
+
+        &::before {
+            content: "ℹ️ Note";
+
+            color: light-dark(oklch(var(--alert-color-light-text) var(--alert-note)),
+                    oklch(var(--alert-color-dark-text) var(--alert-note)));
+        }
+    }
+
+    & .markdown-alert-tip {
+        border-left: 3px solid light-dark(oklch(var(--alert-color-light) var(--alert-tip)),
+                oklch(var(--alert-color-dark) var(--alert-tip)));
+
+        &::before {
+            content: "💡 Tip";
+
+            color: light-dark(oklch(var(--alert-color-light-text) var(--alert-tip)),
+                    oklch(var(--alert-color-dark-text) var(--alert-tip)));
+        }
+    }
+
+    & .markdown-alert-important {
+        border-left: 3px solid light-dark(oklch(var(--alert-color-light) var(--alert-important)),
+                oklch(var(--alert-color-dark) var(--alert-important)));
+
+        &::before {
+            content: "📌 Important";
+
+            color: light-dark(oklch(var(--alert-color-light-text) var(--alert-important)),
+                    oklch(var(--alert-color-dark-text) var(--alert-important)));
+        }
+    }
+
+    & .markdown-alert-warning {
+        border-left: 3px solid light-dark(oklch(var(--alert-color-light) var(--alert-warning)),
+                oklch(var(--alert-color-dark) var(--alert-warning)));
+
+        &::before {
+            content: "⚠️ Warning";
+
+            color: light-dark(oklch(var(--alert-color-light-text) var(--alert-warning)),
+                    oklch(var(--alert-color-dark-text) var(--alert-warning)));
+        }
+    }
+
+    & .markdown-alert-caution {
+        border-left: 3px solid light-dark(oklch(var(--alert-color-light) var(--alert-caution)),
+                oklch(var(--alert-color-dark) var(--alert-caution)));
+
+        &::before {
+            content: "🛑 Caution";
+
+            color: light-dark(oklch(var(--alert-color-light-text) var(--alert-caution)),
+                    oklch(var(--alert-color-dark-text) var(--alert-caution)));
+        }
     }
 }
 

--- a/zola.toml
+++ b/zola.toml
@@ -12,7 +12,10 @@ default_language = "en"
 generate_feeds = true
 feed_filenames = ["atom.xml", "rss.xml"]
 
+
 [markdown]
+github_alerts = true
+
 insert_anchor_links = "heading"
 
 [markdown.highlighting]


### PR DESCRIPTION
#### Description
Add support for Github Alerts within Markdown

#### Image

<img width="1266" height="145" alt="image" src="https://github.com/user-attachments/assets/1efca50a-60a9-4b92-8596-1f3796104e8e" />

<img width="907" height="155" alt="image" src="https://github.com/user-attachments/assets/80df36d1-6ed7-45a8-9034-42ebcfe02643" />
